### PR TITLE
Fix terminal focus

### DIFF
--- a/src/package-with-comment.json
+++ b/src/package-with-comment.json
@@ -1542,8 +1542,8 @@
             {
                 "key": "alt+f12",
                 "mac": "alt+f12",
-                "command": "workbench.action.terminal.toggleTerminal",
-                "intellij": "Open corresponding tool window (Terminal)"
+                "command": "workbench.action.terminal.focus",
+                "intellij": "Opens and focuses corresponding tool window (Terminal)"
             },
             {
                 "key": "ctrl+shift+alt+j",


### PR DESCRIPTION
Should be ```workbench.action.terminal.focus``` because the present command implementation ```workbench.action.terminal.toggleTerminal``` actually toggles the terminal but it does not focus it like it does on IntelliJ.